### PR TITLE
Enhance usage helptext

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ it from beginning to end and counting various metrics.
              kafka-topic-analyzer [FLAGS] --bootstrap-server <BOOTSTRAP_SERVER> --topic <TOPIC>
 
          FLAGS:
-             -c, --count-alive-keys  <PATH_TO_STATE_DIR>    Counts the effective number of alive keys in a log compacted topic by saving the state for
-                                                            each key in a local file and counting the result at the end of the read operation.A key is
-                                                            'alive' when it is present and has a non-null value in it's latest-offset version.Requires
-                                                            a filesystem path where the keys are stored temporarily.
-             -h, --help                                     Prints help information
-             -V, --version                                  Prints version information
+             -c, --count-alive-keys  <LOCAL_ALIVE_KEYS_STORAGE_PATH>    Counts the effective number of alive keys in a log compacted topic by saving the state for
+                                                                        each key in a local file and counting the result at the end of the read operation.A key is
+                                                                        'alive' when it is present and has a non-null value in it's latest-offset version.Requires
+                                                                        a storage path where the keys are stored temporarily.
+             -h, --help                                                 Prints help information
+             -V, --version                                              Prints version information
 
          OPTIONS:
              -b, --bootstrap-server <BOOTSTRAP_SERVER>    Bootstrap server(s) to work with, comma separated

--- a/README.md
+++ b/README.md
@@ -14,19 +14,17 @@ it from beginning to end and counting various metrics.
              kafka-topic-analyzer [FLAGS] --bootstrap-server <BOOTSTRAP_SERVER> --topic <TOPIC>
 
          FLAGS:
-             -c, --count-alive-keys  <LOCAL_ALIVE_KEYS_STORAGE_PATH>    Counts the effective number of alive keys in a log compacted topic by saving the state for
-                                                                        each key in a local file and counting the result at the end of the read operation.A key is
-                                                                        'alive' when it is present and has a non-null value in it's latest-offset version.Requires
-                                                                        a storage path where the keys are stored temporarily.
              -h, --help                                                 Prints help information
              -V, --version                                              Prints version information
 
          OPTIONS:
-             -b, --bootstrap-server <BOOTSTRAP_SERVER>    Bootstrap server(s) to work with, comma separated
-             -t, --topic <TOPIC>                          The topic to analyze
+             -b, --bootstrap-server <BOOTSTRAP_SERVER>                  Bootstrap server(s) to work with, comma separated
+             -c, --count-alive-keys <LOCAL_ALIVE_KEYS_STORAGE_PATH>     Counts the effective number of alive keys in a log compacted topic by saving the state for
+                                                                        each key in a local file and counting the result at the end of the read operation.A key is
+                                                                        'alive' when it is present and has a non-null value in it's latest-offset version.Requires
+                                                                        a storage path where the keys are stored temporarily.
+             -t, --topic <TOPIC>                                        The topic to analyze
 
-## Example output
-![Screenshot from a terminal that shows an example of the output](demo_output.png "Shows a sample output of the tool")
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ it from beginning to end and counting various metrics.
              kafka-topic-analyzer [FLAGS] --bootstrap-server <BOOTSTRAP_SERVER> --topic <TOPIC>
 
          FLAGS:
-             -c, --count-alive-keys    Counts the effective number of alive keys in a log compacted topic by saving the state for
-                                       each key in a local file and counting the result at the end of the read operation.A key is
-                                       'alive' when it is present and has a non-null value in it's latest-offset version
-             -h, --help                Prints help information
-             -V, --version             Prints version information
+             -c, --count-alive-keys  <PATH_TO_STATE_DIR>    Counts the effective number of alive keys in a log compacted topic by saving the state for
+                                                            each key in a local file and counting the result at the end of the read operation.A key is
+                                                            'alive' when it is present and has a non-null value in it's latest-offset version.Requires
+                                                            a filesystem path where the keys are stored temporarily.
+             -h, --help                                     Prints help information
+             -V, --version                                  Prints version information
 
          OPTIONS:
              -b, --bootstrap-server <BOOTSTRAP_SERVER>    Bootstrap server(s) to work with, comma separated


### PR DESCRIPTION
I just stumbled upon the fact that the readme didn't mention that specifying a local path is required if the tool is invoked with `-c`.

I also moved the `-c` section from `flags` to `options` because that's how it is shown in the actual output of the help text.