### PR TITLE
Fix usage of message timestamp

### DIFF
--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -88,9 +88,9 @@ impl<'a> TopicAnalyzer<'a> {
                     let partition = m.partition();
                     let offset = m.offset();
 
-
-                    let parsed_naive_timestamp = NaiveDateTime::from_timestamp(m.timestamp().to_millis().unwrap() / 1000, 0);
-                    let timestamp = DateTime::<Utc>::from_utc(parsed_naive_timestamp, Utc);
+                    let timestamp = m.timestamp().to_millis().unwrap_or(0);
+                    let parsed_naive_timestamp = NaiveDateTime::from_timestamp(timestamp / 1000, 0);
+                    let timestamp_dt = DateTime::<Utc>::from_utc(parsed_naive_timestamp, Utc);
 
                     for mh in self.metric_handlers.iter_mut() {
                         mh.handle_message(&m);
@@ -98,7 +98,7 @@ impl<'a> TopicAnalyzer<'a> {
 
                     pb.set_message(
                         format!("[Sq: {} | T: {} | P: {} | O: {} | Ts: {}]",
-                                seq, topic, partition, offset, timestamp).as_str());
+                                seq, topic, partition, offset, timestamp_dt).as_str());
 
                     if let Err(e) = self.consumer.store_offset(&m) {
                         warn!("Error while storing offset: {}", e);

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -206,8 +206,9 @@ impl MessageMetrics {
 impl MetricHandler for MessageMetrics {
     fn handle_message<'b>(&mut self, m: &BorrowedMessage<'b>) where BorrowedMessage<'b>: Message {
         let partition = m.partition();
-        let parsed_naive_timestamp = NaiveDateTime::from_timestamp(m.timestamp().to_millis().unwrap() / 1000, 0);
-        let timestamp = DateTime::<Utc>::from_utc(parsed_naive_timestamp, Utc);
+        let timestamp = m.timestamp().to_millis().unwrap_or(0);
+        let parsed_naive_timestamp = NaiveDateTime::from_timestamp(timestamp / 1000, 0);
+        let timestamp_dt = DateTime::<Utc>::from_utc(parsed_naive_timestamp, Utc);
         let mut message_size: u64 = 0;
         let mut empty_value = false;
 
@@ -243,7 +244,7 @@ impl MetricHandler for MessageMetrics {
             }
         }
 
-        self.cmp_and_set_message_timestamp(timestamp);
+        self.cmp_and_set_message_timestamp(timestamp_dt);
 
         if !empty_value {
             self.cmp_and_set_message_size(message_size);


### PR DESCRIPTION
At the moment the tool fails with the following error if a message has no timestamp:

```
Subscribing to topic_xyz
Starting message consumption...
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', libcore/option.rs:345:21
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

The timestamp of a kafka message is optional, thus it needs special treatment.
I have decided to set the timestamp to `0` in case it does not exist, I am open for other `fallback `suggestions :)